### PR TITLE
0.6.0 invalid gemspec

### DIFF
--- a/rerun.gemspec
+++ b/rerun.gemspec
@@ -4,7 +4,6 @@ $spec = Gem::Specification.new do |s|
 
   s.name = 'rerun'
   s.version = '0.6.0'
-  s.date = '2011-05-15'
 
   s.description = "Restarts your app when a file changes"
   s.summary     = "Launches an app, and restarts it whenever the filesystem changes."


### PR DESCRIPTION
Deleted the date, since it should not be set manually. This follows the [Gem::Specification](http://rubygems.rubyforge.org/rubygems-update/Gem/Specification.html#method-i-date-3D).
