### PR TITLE
add option to specify default termination signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ Procfile processes locally and restart them all when necessary.
 By default it watches files ending in: `rb,js,css,scss,sass,erb,html,haml,ru`.
 It also ignores directories named `.rbx .bundle .git .svn log tmp vendor` and files named `.DS_Store`.
 
+`--signal` (or -s) use specified signal (instead of the default SIGTERM) to terminate the previous process.
+This may be useful for forcing the respective process to terminate as quickly as possible.
+(`--signal KILL` is the equivalent of `kill -9`)
+
 `--clear` (or -c) clear the screen before each run
 
 `--exit` (or -x) expect the program to exit. With this option, rerun checks the return value; without it, rerun checks that the launched process is still running.

--- a/bin/rerun
+++ b/bin/rerun
@@ -29,6 +29,10 @@ opts = OptionParser.new("", 24, '  ') { |opts|
     options[:pattern] = pattern
   end
 
+  opts.on("-s", "--signal", "terminate process using a signal other than SIGTERM") do |signal|
+    options[:signal] = signal
+  end
+
   opts.on("-c", "--clear", "clear screen before each run") do
     options[:clear] = true
   end

--- a/lib/rerun/runner.rb
+++ b/lib/rerun/runner.rb
@@ -181,12 +181,13 @@ module Rerun
 
     # todo: test escalation
     def stop
+      default_signal = @options[:signal] || "TERM"
       if @pid && (@pid != 0)
         notify "stopping", "All good things must come to an end." unless @restarting
         begin
           timeout(4) do  # todo: escalation timeout setting
             # start with a polite SIGTERM
-            signal("TERM") && Process.wait(@pid)
+            signal(default_signal) && Process.wait(@pid)
           end
         rescue Timeout::Error
           begin


### PR DESCRIPTION
this addresses #26, though I opted to allow for any arbitrary signal rather than just `-9` for SIGKILL - I figured anyone using this should know what they're doing

please note the commit message
