### PR TITLE
Fixes #30

### DIFF
--- a/lib/rerun/options.rb
+++ b/lib/rerun/options.rb
@@ -1,7 +1,8 @@
 require 'optparse'
 
 libdir = "#{File.expand_path(File.dirname(File.dirname(__FILE__)))}"
-load "#{libdir}/../rerun.gemspec" # defines "$spec" variable, which we read the version from
+
+$spec = Gem::Specification.load(File.join(libdir, "..", "rerun.gemspec"))
 
 module Rerun
   class Options


### PR DESCRIPTION
When installing a gem it rewrites the gemspec file and it removes the $spec variable. If we use Gem::Specification.load we don't need to rely on the format of the gemspec file.
