### PR TITLE
Add toggle pause key command

### DIFF
--- a/lib/rerun/runner.rb
+++ b/lib/rerun/runner.rb
@@ -30,6 +30,8 @@ module Rerun
             when 'r'
               say "Restarting"
               restart
+            when 'p'
+              toggle_pause if watcher_running?
             when 'x', 'q'
               die
               break  # the break will stop this thread, in case the 'die' doesn't
@@ -37,6 +39,7 @@ module Rerun
               puts "\n#{c.inspect} pressed inside rerun"
               puts [["c", "clear screen"],
                ["r", "restart"],
+               ["p", "toggle pause"],
                ["x or q", "stop and exit"]
               ].map{|key, description| "  #{key} -- #{description}"}.join("\n")
               puts
@@ -58,6 +61,26 @@ module Rerun
       stop
       start
       @restarting = false
+    end
+
+    def watcher_running?
+      @watcher && @watcher.running?
+    end
+
+    def toggle_pause
+      unless @pausing
+        say "Pausing.  Press 'p' again to resume."
+        @watcher.pause
+        @pausing = true
+      else
+        say "Resuming"
+        @watcher.unpause
+        @pausing = false
+      end
+    end
+
+    def unpause
+      @watcher.unpause
     end
 
     def dir

--- a/lib/rerun/watcher.rb
+++ b/lib/rerun/watcher.rb
@@ -93,5 +93,18 @@ module Rerun
     rescue Interrupt => e
       # don't care
     end
+
+    def pause
+      @listener.pause if @listener
+    end
+
+    def unpause
+      @listener.unpause if @listener
+    end
+
+    def running?
+      @listener && @listener.instance_variable_get(:@adapter)
+    end
+
   end
 end

--- a/spec/watcher_spec.rb
+++ b/spec/watcher_spec.rb
@@ -103,6 +103,23 @@ module Rerun
       create "#{@dir}/.DS_Store"
       @log.should be_nil
     end
+
+    it "disables watcher when paused" do
+      @watcher.pause
+      create "#{@dir}/pause_test.txt"
+      @log.should be_nil
+    end
+
+    it "pauses and resumes watcher" do
+      @watcher.pause
+      create "#{@dir}/pause_test.txt"
+      @log.should be_nil
+      @watcher.unpause
+      test_file = "#{@dir}/pause_test2.txt"
+      create test_file
+      @log[:added].should == [test_file]
+    end
+
   end
 
 end


### PR DESCRIPTION
Sometimes, the user may want to pause the file scanning (maybe, he wants to modify several files and doesn't want rerun to keep restarting as each is saved).  This feature adds a pause toggle key command (press 'p') which pauses and un-pauses the file watcher.
- Add call to new Watcher functions pause and unpause
- Add call to Listener#pause and Listener#unpause
- Add spec for testing pause toggle
