### PR TITLE
An alternative (hopefully better) way to specify multiple dirs

### DIFF
--- a/lib/rerun/options.rb
+++ b/lib/rerun/options.rb
@@ -7,9 +7,9 @@ $spec = Gem::Specification.load(File.join(libdir, "..", "rerun.gemspec"))
 module Rerun
   class Options
     DEFAULT_PATTERN = "**/*.{rb,js,css,scss,sass,erb,html,haml,ru}"
+    DEFAULT_DIRS = ["."]
 
     DEFAULTS = {
-        :dir => ["."],
         :pattern => DEFAULT_PATTERN,
         :signal => "TERM",
         :growl => true,
@@ -27,8 +27,9 @@ module Rerun
         opts.separator ""
         opts.separator "Options:"
 
-        opts.on("-d dir", "--dir dir", "directory to watch, default = \"#{DEFAULTS[:dir]}\". Separate multiple paths with ','.") do |dir|
-          options[:dir] = dir.split(",")
+        opts.on("-d dir", "--dir dir", "directory to watch, default = \"#{DEFAULT_DIRS}\".  Specify multiple paths with ',' or separate '-d dir' option pairs.") do |dir|
+          elements = dir.split(",")
+          options[:dir] = (options[:dir] || []) + elements
         end
 
         opts.on("-p pattern", "--pattern pattern", "file glob, default = \"#{DEFAULTS[:pattern]}\"") do |pattern|
@@ -72,6 +73,7 @@ module Rerun
       else
         opts.parse! args
         options[:cmd] = args.join(" ")
+        options[:dir] ||= DEFAULT_DIRS
         options
       end
     end

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -38,5 +38,26 @@ module Rerun
       options = Options.parse ["--dir", "a,b", "foo"]
       assert { options[:dir] == ["a", "b"] }
     end
+
+    it "adds directories specified individually with --dir" do
+      options = Options.parse ["--dir", "a", "--dir", "b"]
+      assert { options[:dir] == ["a", "b"] }
+    end
+
+    it "adds directories specified individually with -d" do
+      options = Options.parse ["-d", "a", "-d", "b"]
+      assert { options[:dir] == ["a", "b"] }
+    end
+
+    it "adds directories specified individually using mixed -d and --dir" do
+      options = Options.parse ["-d", "a", "--dir", "b"]
+      assert { options[:dir] == ["a", "b"] }
+    end
+
+    it "adds individual directories and splits comma-separated ones" do
+      options = Options.parse ["--dir", "a", "--dir", "b", "--dir", "foo,other"]
+      assert { options[:dir] == ["a", "b", "foo", "other"] }
+    end
+
   end
 end


### PR DESCRIPTION
Provides a more convenient method to specify multiple dirs instead of
in a comma-separated list.  For example, user can indicate multiple dirs
this way:

  $ rerun -d example_dir -d ../tmp/dir "rake spec"

One advantage of this method is that the user gets the benefit of auto-completion when typing the paths on the command line.
- Also add some unit tests to support new options.
- Old-style comma-separated dirs are still supported.
