### PR TITLE
support OSX notifications as alternative to growl

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "http://rubygems.org"
 
 gemspec
 

--- a/lib/rerun.rb
+++ b/lib/rerun.rb
@@ -2,6 +2,7 @@ here = File.expand_path(File.dirname(__FILE__))
 $: << here unless $:.include?(here)
 
 require "listen"  # pull in the Listen gem
+require "terminal-notifier" #pull in the TerminalNotifier
 require "rerun/options"
 require "rerun/system"
 require "rerun/runner"

--- a/lib/rerun/options.rb
+++ b/lib/rerun/options.rb
@@ -13,6 +13,7 @@ module Rerun
         :pattern => DEFAULT_PATTERN,
         :signal => "TERM",
         :growl => true,
+        :osx_notifications => false
     }
 
     def self.parse args = ARGV
@@ -52,6 +53,11 @@ module Rerun
         end
 
         opts.on("--no-growl", "don't use growl") do
+          options[:growl] = false
+        end
+
+        opts.on("-on", "--osx-notifications", "use OS X Notifications") do
+          options[:osx_notifications] = true
           options[:growl] = false
         end
 

--- a/lib/rerun/runner.rb
+++ b/lib/rerun/runner.rb
@@ -224,6 +224,7 @@ module Rerun
 
     def notify(title, body)
       growl title, body if @options[:growl]
+      osx_notifications title, body if @options[:osx_notifications]
       puts
       say "#{app_name} #{title}"
     end

--- a/lib/rerun/system.rb
+++ b/lib/rerun/system.rb
@@ -45,5 +45,15 @@ module Rerun
       end
     end
 
+    def osx_notifications(title, body)
+      if osx_notifications_available?
+        TerminalNotifier.notify(body, :title => "#{app_name} #{title} - rerun")
+      end
+    end
+
+    def osx_notifications_available?
+      mac? && TerminalNotifier.available?
+    end
+
   end
 end

--- a/rerun.gemspec
+++ b/rerun.gemspec
@@ -3,7 +3,7 @@ $spec = Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
 
   s.name = 'rerun'
-  s.version = '0.8.1'
+  s.version = '0.8.2'
 
   s.description = "Restarts your app when a file changes. A no-frills, command-line alternative to Guard, Shotgun, Autotest, etc."
   s.summary     = "Launches an app, and restarts it whenever the filesystem changes. A no-frills, command-line alternative to Guard, Shotgun, Autotest, etc."
@@ -26,6 +26,7 @@ $spec = Gem::Specification.new do |s|
   s.extra_rdoc_files = %w[README.md]
 
   s.add_dependency 'listen', '>= 1.0.3'
+  s.add_dependency 'terminal-notifier', '>= 1.4.2'
 
   s.homepage = "http://github.com/alexch/rerun/"
   s.require_paths = %w[lib]

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -13,6 +13,7 @@ module Rerun
       assert { defaults[:pattern] == Options::DEFAULT_PATTERN }
       assert { defaults[:signal] == "TERM" }
       assert { defaults[:growl] == true }
+      assert { defaults[:osx_notifications] == false }
 
       assert { defaults[:clear].nil? }
       assert { defaults[:exit].nil? }
@@ -32,6 +33,13 @@ module Rerun
     it "accepts --no-growl" do
       options = Options.parse ["--no-growl", "foo"]
       assert { options[:growl] == false }
+    end
+    ["--osx-notifications", "-on"].each do |arg|
+      it "accepts #{arg}" do
+        options = Options.parse [arg, "foo"]
+        assert { options[:growl] == false }
+        assert { options[:osx_notifications] == true }
+      end
     end
 
     it "splits directories" do


### PR DESCRIPTION
I have coded the OSX Notifications support for rerun. It uses [terminal-notifier](https://github.com/alloy/terminal-notifier) gem. And you can use it with two different arguments: `-on` or `--osx-notifications`. If you will use it will disable the growl notifications.

Related to issue: #33

How it looks? See here: ![OS X notifications for rerun gem](http://f.cl.ly/items/1q302F041i2I0j1l113U/Screen%20Shot%202013-06-14%20o%2012.11.40.png) 