### PR TITLE
Fixing(setting) listen version to 1.0.x.

### DIFF
--- a/rerun.gemspec
+++ b/rerun.gemspec
@@ -25,7 +25,7 @@ $spec = Gem::Specification.new do |s|
 
   s.extra_rdoc_files = %w[README.md]
 
-  s.add_dependency 'listen', '>= 1.0.3'
+  s.add_dependency 'listen', '~> 1.0'
 
   s.homepage = "http://github.com/alexch/rerun/"
   s.require_paths = %w[lib]


### PR DESCRIPTION
Listen 2.0.0 was released, and the method Listener#start! was removed.
The new version is throwing the following exception on rerun:

```
    rerun-0.8.1/lib/rerun/watcher.rb:62:in `block in start':
    undefined method `start!' for #<Listen::Listener:0x007fe764a47ee8>
    (NoMethodError)
```
