### PR TITLE
Define missing error to prevent a NameError

### DIFF
--- a/lib/rerun/watcher.rb
+++ b/lib/rerun/watcher.rb
@@ -12,6 +12,8 @@ Thread.abort_on_exception = true
 #
 module Rerun
   class Watcher
+    InvalidDirectoryError = Class.new(RuntimeError)
+
     attr_reader :directory, :pattern, :priority
 
     # Create a file system watcher. Start it by calling #start.


### PR DESCRIPTION
To reproduce the issue, run:

``` bash
ruby -Ilib bin/rerun -d this-directory-probably-doesnt-exist-on-your-machine-either 'echo hi'
```
