### PR TITLE
Configurable app name via --name

### DIFF
--- a/lib/rerun/options.rb
+++ b/lib/rerun/options.rb
@@ -1,4 +1,5 @@
 require 'optparse'
+require 'pathname'
 
 libdir = "#{File.expand_path(File.dirname(File.dirname(__FILE__)))}"
 
@@ -13,6 +14,7 @@ module Rerun
         :pattern => DEFAULT_PATTERN,
         :signal => "TERM",
         :growl => true,
+        :name => Pathname.getwd.basename.to_s.capitalize
     }
 
     def self.parse args = ARGV
@@ -50,6 +52,10 @@ module Rerun
 
         opts.on("-b", "--background", "disable on-the-fly commands, allowing the process to be backgrounded") do
           options[:background] = true
+        end
+
+        opts.on("-n name", "--name name", "name of app used in logs and notifications, default = \"#{DEFAULTS[:name]}\"") do |name|
+          options[:name] = name
         end
 
         opts.on("--no-growl", "don't use growl") do

--- a/lib/rerun/runner.rb
+++ b/lib/rerun/runner.rb
@@ -80,6 +80,10 @@ module Rerun
       @options[:exit]
     end
 
+    def app_name
+      @options[:name]
+    end
+
     def start
       if windows?
         raise "Sorry, Rerun does not work on Windows."

--- a/lib/rerun/system.rb
+++ b/lib/rerun/system.rb
@@ -24,11 +24,6 @@ module Rerun
       growlnotify
     end
 
-    def app_name
-      # todo: make sure this works in non-Mac and non-Unix environments
-      File.expand_path(".").gsub(/^.*\//, '').capitalize
-    end
-
     def icon
       here = File.expand_path(File.dirname(__FILE__))
       icondir = File.expand_path("#{here}/../../icons")

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -13,6 +13,7 @@ module Rerun
       assert { defaults[:pattern] == Options::DEFAULT_PATTERN }
       assert { defaults[:signal] == "TERM" }
       assert { defaults[:growl] == true }
+      assert { defaults[:name] == 'Rerun' }
 
       assert { defaults[:clear].nil? }
       assert { defaults[:exit].nil? }
@@ -57,6 +58,11 @@ module Rerun
     it "adds individual directories and splits comma-separated ones" do
       options = Options.parse ["--dir", "a", "--dir", "b", "--dir", "foo,other"]
       assert { options[:dir] == ["a", "b", "foo", "other"] }
+    end
+
+    it "accepts --name for a custom application name" do
+      options = Options.parse ["--name", "scheduler"]
+      assert { options[:name] == "scheduler" }
     end
 
   end


### PR DESCRIPTION
Also using Pathname for (hopefully) better cross-platform compatibility for the default name.

Addresses my request in #49 :)
