### PR TITLE
Add feature files to default pattern and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Rerun's advantage is its simple design. Since it uses `exec` and the standard
 Unix `SIGINT` and `SIGKILL` signals, you're sure the restarted app is really
 acting just like it was when you ran it from the command line the first time.
 
-By default only `*.{rb,js,css,coffee,scss,sass,erb,html,haml,ru,slim,md}` files are watched.
+By default it watches files ending in: `rb,js,coffee,css,scss,sass,erb,html,haml,ru,yml,slim,md,feature`.
 Use the `--pattern` option if you want to change this.
 
 As of version 0.7.0, we use the Listen gem, which tries to use your OS's
@@ -116,7 +116,7 @@ Procfile processes locally and restart them all when necessary.
 `--dir` directory (or directories) to watch (default = "."). Separate multiple paths with ',' and/or use multiple `-d` options.
 
 `--pattern` glob to match inside directory. This uses the Ruby Dir glob style -- see <http://www.ruby-doc.org/core/classes/Dir.html#M002322> for details.
-By default it watches files ending in: `rb,js,css,coffee,scss,sass,erb,html,haml,ru,slim,md`.
+By default it watches files ending in: `rb,js,coffee,css,scss,sass,erb,html,haml,ru,yml,slim,md,feature`.
 On top of this, it also ignores dotfiles, `.tmp` files, and some other files and directories (like `.git` and `log`).
 Run `rerun --help` to see the actual list.
 

--- a/lib/rerun/options.rb
+++ b/lib/rerun/options.rb
@@ -7,7 +7,7 @@ $spec = Gem::Specification.load(File.join(libdir, "..", "rerun.gemspec"))
 
 module Rerun
   class Options
-    DEFAULT_PATTERN = "**/*.{rb,js,coffee,css,scss,sass,erb,html,haml,ru,yml,slim,md}"
+    DEFAULT_PATTERN = "**/*.{rb,js,coffee,css,scss,sass,erb,html,haml,ru,yml,slim,md,feature}"
     DEFAULT_DIRS = ["."]
 
     DEFAULTS = {


### PR DESCRIPTION
`xxx.feature` files are commonly used for Gherkin based stuff, e.g. Cucumber or Turnip feature tests.

I also noticed that your README wasn't up2date and fixed it.