### PR TITLE
add --ignore-dotfiles and disable ignoring by default

### DIFF
--- a/lib/rerun/options.rb
+++ b/lib/rerun/options.rb
@@ -38,6 +38,10 @@ module Rerun
           options[:pattern] = pattern
         end
 
+        opts.on("-i", "--ignore-dotfiles", "ignore any changes to files and dirs starting with a dot") do
+          options[:ignore_dotfiles] = true
+        end
+
         opts.on("-s", "--signal signal", "terminate process using this signal, default = \"#{DEFAULTS[:signal]}\"") do |signal|
           options[:signal] = signal
         end

--- a/lib/rerun/runner.rb
+++ b/lib/rerun/runner.rb
@@ -101,6 +101,10 @@ module Rerun
       @options[:clear]
     end
 
+    def ignore_dotfiles?
+      @options[:ignore_dotfiles]
+    end
+
     def exit?
       @options[:exit]
     end
@@ -175,7 +179,7 @@ module Rerun
 
       unless @watcher
 
-        watcher = Watcher.new(:directory => dirs, :pattern => pattern) do |changes|
+        watcher = Watcher.new(:directory => dirs, :pattern => pattern, :ignore_dotfiles => ignore_dotfiles?) do |changes|
 
           message = [:modified, :added, :removed].map do |change|
             count = changes[change].size

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -11,6 +11,7 @@ module Rerun
 
       assert { defaults[:dir] == ["."] }
       assert { defaults[:pattern] == Options::DEFAULT_PATTERN }
+      assert { defaults[:ignore_dotfiles].nil? }
       assert { defaults[:signal] == "TERM" }
       assert { defaults[:growl] == true }
       assert { defaults[:name] == 'Rerun' }


### PR DESCRIPTION
I added an option to enable the filtering of dotfiles. It's disabled by default, because otherwise it's impossible with the current setup to detect changes to them (because of the order in which Listen finds & filters files).

If you think it should be enabled by default though, I'm open to changing this though.
