### PR TITLE
Clean Up Tests

### DIFF
--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -26,7 +26,7 @@ module Rerun
 
       it "clears the screen" do
         runner = Runner.new("foo.rb", {:clear => true})
-        runner.clear?.should be_true
+        runner.clear?.should be_truthy
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,3 +9,7 @@ here = File.expand_path(File.dirname(__FILE__))
 $: << File.expand_path("#{here}/../lib")
 
 require "rerun"
+
+RSpec.configure do |config|
+  config.expect_with(:rspec) { |c| c.syntax = %i[expect should] }
+end

--- a/spec/watcher_spec.rb
+++ b/spec/watcher_spec.rb
@@ -99,7 +99,9 @@ module Rerun
       @log.should be_nil
     end
 
-    ignored_directories = Listen::Silencer::DEFAULT_IGNORED_DIRECTORIES
+    ignored_directories = %w[
+      .git .svn .hg .rbx .bundle bundle vendor/bundle log tmp vendor/ruby
+    ]
     it "ignores directories named #{ignored_directories}" do
       ignored_directories.each do |ignored_dir|
         FileUtils.mkdir_p "#{@dir}/#{ignored_dir}"


### PR DESCRIPTION
I needed these changes to get the tests running more clean (I still have some noisy log output) on my machine.  I believe they are due to me using newer versions of the libraries locally.

A better fix for the `expect()`/`should()` mismatch would be to migrate everything to `expect()`, but that was a bigger change.  I would also like to see the test logging made optional as it's pretty noisy.  I also feel files like `inc.rb` should be moved to `spec/support` or similar to clean up the root directory.  Those are just my preferences though and I don't make those changes here.