### PR TITLE
Add support for restarting with SIGHUP

### DIFF
--- a/lib/rerun/options.rb
+++ b/lib/rerun/options.rb
@@ -14,6 +14,7 @@ module Rerun
     DEFAULTS = {
         :pattern => DEFAULT_PATTERN,
         :signal => "TERM",
+        :hup => false,
         :growl => true,
         :name => Pathname.getwd.basename.to_s.capitalize,
         :ignore => []
@@ -47,6 +48,10 @@ module Rerun
 
         opts.on("-s signal", "--signal signal", "terminate process using this signal, default = \"#{DEFAULTS[:signal]}\"") do |signal|
           options[:signal] = signal
+        end
+
+        opts.on('-h', '--hup', "sends SIGHUP and lets process restart by itself (implies --signal HUP)") do
+          options[:hup] = true
         end
 
         opts.on("-c", "--clear", "clear screen before each run") do

--- a/lib/rerun/runner.rb
+++ b/lib/rerun/runner.rb
@@ -60,8 +60,12 @@ module Rerun
 
     def restart
       @restarting = true
-      stop
-      start
+      if hup?
+        signal('HUP')
+      else
+        stop
+        start
+      end
       @restarting = false
     end
 
@@ -111,6 +115,10 @@ module Rerun
 
     def app_name
       @options[:name]
+    end
+
+    def hup?
+      @options[:hup]
     end
 
     def start


### PR DESCRIPTION
Useful with unicorn and other processes that can do the right thing when
sent a SIGHUP.

This is an somewhat simpler alternative to the proposal at #31