### PR TITLE
Add a --force-polling option

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ This may be useful for forcing the respective process to terminate as quickly as
 
 `--name` set the app name (for display)
 
+`--force-polling` force polling
+
 Also `--version` and `--help`, naturally.
 
 # Growl Notifications

--- a/lib/rerun/options.rb
+++ b/lib/rerun/options.rb
@@ -16,6 +16,7 @@ module Rerun
         :signal => "TERM",
         :growl => true,
         :name => Pathname.getwd.basename.to_s.capitalize,
+        :force_polling => false,
         :ignore => []
     }
 
@@ -63,6 +64,10 @@ module Rerun
 
         opts.on("-n name", "--name name", "name of app used in logs and notifications, default = \"#{DEFAULTS[:name]}\"") do |name|
           options[:name] = name
+        end
+
+        opts.on("--force-polling", "use force polling") do
+          options[:force_polling] = true
         end
 
         opts.on("--no-growl", "don't use growl") do

--- a/lib/rerun/runner.rb
+++ b/lib/rerun/runner.rb
@@ -113,6 +113,10 @@ module Rerun
       @options[:name]
     end
 
+    def force_polling
+      @options[:force_polling]
+    end
+
     def start
       if windows?
         raise "Sorry, Rerun does not work on Windows."
@@ -179,7 +183,7 @@ module Rerun
 
       unless @watcher
 
-        watcher = Watcher.new(:directory => dirs, :pattern => pattern, :ignore => ignore) do |changes|
+        watcher = Watcher.new(:directory => dirs, :pattern => pattern, :ignore => ignore, :force_polling => force_polling) do |changes|
 
           message = change_message(changes)
 

--- a/lib/rerun/watcher.rb
+++ b/lib/rerun/watcher.rb
@@ -39,6 +39,7 @@ module Rerun
       @directories = options[:directory]
       @directories = sanitize_dirs(@directories)
       @priority = options[:priority]
+      @force_polling = options[:force_polling]
       @ignore = [options[:ignore]].flatten.compact
       @thread = nil
     end
@@ -60,7 +61,7 @@ module Rerun
       end
 
       @thread = Thread.new do
-        @listener = Listen.to(*@directories, only: watching, ignore: ignoring, wait_for_delay: 1) do |modified, added, removed|
+        @listener = Listen.to(*@directories, only: watching, ignore: ignoring, wait_for_delay: 1, force_polling: @force_polling) do |modified, added, removed|
           if((modified.size + added.size + removed.size) > 0)
             @client_callback.call(:modified => modified, :added => added, :removed => removed)
           end

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -14,6 +14,7 @@ module Rerun
       assert { defaults[:signal] == "TERM" }
       assert { defaults[:growl] == true }
       assert { defaults[:name] == 'Rerun' }
+      assert { defaults[:force_polling] == false }
 
       assert { defaults[:clear].nil? }
       assert { defaults[:exit].nil? }
@@ -63,6 +64,11 @@ module Rerun
     it "accepts --name for a custom application name" do
       options = Options.parse ["--name", "scheduler"]
       assert { options[:name] == "scheduler" }
+    end
+
+    it "accepts --force-polling to force listener polling" do
+      options = Options.parse ["--force-polling"]
+      assert { options[:force_polling] == true }
     end
 
     it "accepts --ignore" do


### PR DESCRIPTION
This is useful when you have an app you want to rerun inside a virtual machine, typically using Vagrant, and the host file system is shared with the guest through /vagrant.  Without the force polling option, changes made in the /vagrant file system are not picked up.