### PR TITLE
Fix restart_with_signal invocation in Rerun::Runner

### DIFF
--- a/lib/rerun/runner.rb
+++ b/lib/rerun/runner.rb
@@ -61,7 +61,7 @@ module Rerun
     def restart
       @restarting = true
       if @options[:restart]
-        restart_with_signal(options[:signal])
+        restart_with_signal(@options[:signal])
       else
         stop
         start


### PR DESCRIPTION
This is a fix for issue #86. `@options` is incorrectly referred to as `options` in the `Rerun::Runner#restart()` method. 