### PR TITLE
Fix Object#timeout deprecation warning in Ruby 2.3

### DIFF
--- a/lib/rerun/runner.rb
+++ b/lib/rerun/runner.rb
@@ -13,6 +13,7 @@ module Rerun
     end
 
     include System
+    include ::Timeout
 
     def initialize(run_command, options = {})
       @run_command, @options = run_command, options


### PR DESCRIPTION
Fix the following warning by explicitly including the `Timeout` module, rather than relying on `Object#timeout`:

```
lib/rerun/runner.rb:254:in `stop': Object#timeout is deprecated, use Timeout.timeout instead
```

Fixes #92 

/cc @mwpastore 