### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ By default it watches files ending in: `rb,js,coffee,css,scss,sass,erb,html,haml
 On top of this, it also ignores dotfiles, `.tmp` files, and some other files and directories (like `.git` and `log`).
 Run `rerun --help` to see the actual list.
 
-`--ignore pattern` file glob to ignore (can be set many times). To ignore a directory, you must append '/*' e.g.
+`--ignore pattern` file glob to ignore (can be set many times). To ignore a directory, you must append `'/*'` e.g.
   `--ignore 'coverage/*'`.
 
   *On top of --pattern and --ignore, we ignore any changes to files and dirs starting with a dot.*


### PR DESCRIPTION
Asterisk was getting cut from markdown, resulting in documentation appearing to be wrong.

Old:
![image](https://cloud.githubusercontent.com/assets/1767466/12426913/2dedd884-be91-11e5-8c42-fbd0def47b78.png)

New:
![image](https://cloud.githubusercontent.com/assets/1767466/12426906/23e2f39c-be91-11e5-92ee-e53ded4cd62c.png)
