### PR TITLE
fix deprecated timeout

### DIFF
--- a/lib/rerun/runner.rb
+++ b/lib/rerun/runner.rb
@@ -256,7 +256,7 @@ module Rerun
       if @pid && (@pid != 0)
         notify "stopping", "All good things must come to an end." unless @restarting
         begin
-          timeout(5) do # todo: escalation timeout setting
+          Timeout.timeout(5) do # todo: escalation timeout setting
             # start with a polite SIGTERM
             signal(default_signal) && Process.wait(@pid)
           end


### PR DESCRIPTION
i have recurrently this error which stops my server
/usr/local/bundle/gems/rerun-0.11.0/lib/rerun/runner.rb:254:in `stop': Object#timeout is deprecated, use Timeout.timeout instead.
