### PR TITLE
Fix terminal-notifier Bundler issue

### DIFF
--- a/lib/rerun/notification.rb
+++ b/lib/rerun/notification.rb
@@ -44,7 +44,9 @@ module Rerun
 
     def send(background = true)
       return unless command
-      `#{command}#{" &" if background}`
+      with_clean_env do
+        `#{command}#{" &" if background}`
+      end
     end
 
     def app_name
@@ -60,5 +62,14 @@ module Rerun
       File.expand_path("#{here}/../../icons")
     end
 
+    def with_clean_env
+      if defined?(Bundler)
+        Bundler.with_clean_env do
+          yield
+        end
+      else
+        yield
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes issue https://github.com/alexch/rerun/issues/108

`which` is used to determine if terminal-notifier can run, but then it’s run inside a Bundler environment where terminal-notifier may not exist in the Gemfile.  This then results in:

/gems/bundler-1.12.5/lib/bundler/rubygems_integration.rb:322:in `block in replace_gem': terminal-notifier is not part of the bundle. Add it to Gemfile. (Gem::LoadError)
    from /gems/ruby-2.2.5/bin/terminal-notifier:22:in`<main>'
    from /gems/ruby-2.2.5/bin/ruby_executable_hooks:15:in `eval'
    from /gems/ruby-2.2.5/bin/ruby_executable_hooks:15:in`<main>'
