### PR TITLE
Fix for resume from pause issue (#100)

### DIFF
--- a/lib/rerun/runner.rb
+++ b/lib/rerun/runner.rb
@@ -37,7 +37,7 @@ module Rerun
               say "Stopping and starting"
               restart(false)
             when 'p'
-              toggle_pause if watcher_running?
+              toggle_pause
             when 'x', 'q'
               die
               break # the break will stop this thread, in case the 'die' doesn't
@@ -72,10 +72,6 @@ module Rerun
         start
       end
       @restarting = false
-    end
-
-    def watcher_running?
-      @watcher && @watcher.running?
     end
 
     def toggle_pause


### PR DESCRIPTION
The issue seems to be caused by a change of behavior within the watcher
and ultimately listen module.  Before, it was necessary to check the
internal state of the listen module from the runner module to be able to
resume from pause properly.  However, with the later versions of listen,
this doesn't seem necessary anymore and the decision whether to actually
resume or not can be done by the watcher module.

I was only able to test on Mac though.  So I'm not sure how this behaves on Linux and other OS'es.