### PR TITLE
Ignore which stderr

### DIFF
--- a/lib/rerun/notification.rb
+++ b/lib/rerun/notification.rb
@@ -43,9 +43,9 @@ module Rerun
     end
 
     def command_named(name)
-      which_command = windows? ? 'where.exe' : 'which'
+      which_command = windows? ? 'where.exe %{cmd}' : 'which %{cmd} 2> /dev/null'
       # TODO: remove 'INFO' error message
-      path = `#{which_command} #{name}`.chomp
+      path = `#{which_command % {cmd: name}}`.chomp
       path.empty? ? nil : path
     end
 


### PR DESCRIPTION
GNU `which` (default in GNU/Linux systems) is very verbose when it doesn't find a command, printing to `STDERR` something along those lines when a command is not found:
```
which: no growlnotify in (/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl)
which: no terminal-notifier in (/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl)
```
This isn't a problem in macOS, since the default which in macOS doesn't print to `STDERR`.