### PR TITLE
Bug #124 usage output when args given

### DIFF
--- a/lib/rerun/options.rb
+++ b/lib/rerun/options.rb
@@ -134,7 +134,7 @@ module Rerun
 
       end
 
-      option_parser.parse! args
+      option_parser.parse args
       options = default_options.merge(options)
       options[:cmd] = args.join(" ").strip # todo: better arg word handling
 

--- a/lib/rerun/options.rb
+++ b/lib/rerun/options.rb
@@ -134,11 +134,10 @@ module Rerun
 
       end
 
-      option_parser.parse args
+      puts option_parser if args.empty?
+      option_parser.parse! args
       options = default_options.merge(options)
       options[:cmd] = args.join(" ").strip # todo: better arg word handling
-
-      puts option_parser if args.empty?
 
       options
     end

--- a/rerun.gemspec
+++ b/rerun.gemspec
@@ -3,7 +3,7 @@ $spec = Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
 
   s.name = 'rerun'
-  s.version = '0.13.0'
+  s.version = '0.13.1'
 
   s.description = "Restarts your app when a file changes. A no-frills, command-line alternative to Guard, Shotgun, Autotest, etc."
   s.summary     = "Launches an app, and restarts it whenever the filesystem changes. A no-frills, command-line alternative to Guard, Shotgun, Autotest, etc."

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -168,5 +168,20 @@ module Rerun
       end
     end
 
+    describe 'Usage' do
+      it "is displayed when no args are given" do
+        expect(Options).to receive(:puts) do |args|
+          expect(args.to_s).to match(/^Usage/)
+        end
+
+        Options.parse(args: [])
+      end
+
+      it "is not displayed when args are given" do
+        expect(Options).not_to receive(:puts)
+
+        Options.parse args: ["--name", "echo foo"]
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes bug #124 by calling `OptionParser#parse` instead of `OptionParser#parse!`.