### PR TITLE
Default to --background if $stdin is not a tty

### DIFF
--- a/lib/rerun/options.rb
+++ b/lib/rerun/options.rb
@@ -17,7 +17,7 @@ module Rerun
     DEFAULT_DIRS = ["."]
 
     DEFAULTS = {
-      :background => false,
+      :background => nil,
       :dir => DEFAULT_DIRS,
       :force_polling => false,
       :ignore => [],
@@ -34,6 +34,7 @@ module Rerun
     def self.parse args: ARGV, config_file: nil
 
       default_options = DEFAULTS.dup
+      default_options[:background] = !$stdin.tty?
       options = {
         ignore: []
       }

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -22,7 +22,17 @@ module Rerun
 
       assert {defaults[:clear].nil?}
       assert {defaults[:exit].nil?}
+    end
 
+    it 'defaults to background if stdin is not a tty' do
+      expect($stdin).to receive(:tty?).and_return(false)
+      defaults = Options.parse args: []
+      assert {defaults[:background] == true}
+    end
+
+    it 'defaults to foreground if stdin is a tty' do
+      expect($stdin).to receive(:tty?).and_return(true)
+      defaults = Options.parse args: []
       assert {defaults[:background] == false}
     end
 


### PR DESCRIPTION
Otherwise stty keeps emitting "Inappropriate ioctl for device" errors

Let me know if you want me to include changes to the gemspec version etc too
