### PR TITLE
Add "cpp,hpp,py" to DEFAULT_PATTERN for files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Rerun's advantage is its simple design. Since it uses `exec` and the standard
 Unix `SIGINT` and `SIGKILL` signals, you're sure the restarted app is really
 acting just like it was when you ran it from the command line the first time.
 
-By default it watches files ending in: `rb,js,coffee,css,scss,sass,erb,html,haml,ru,yml,slim,md,feature,c,h`.
+By default it watches files ending in: `rb,js,coffee,css,scss,sass,erb,html,haml,ru,yml,slim,md,feature,c,h,cpp,hpp,py`.
 Use the `--pattern` option if you want to change this.
 
 As of version 0.7.0, we use the Listen gem, which tries to use your OS's

--- a/lib/rerun/options.rb
+++ b/lib/rerun/options.rb
@@ -13,7 +13,7 @@ module Rerun
     extend Rerun::System
 
     # If you change the default pattern, please update the README.md file -- the list appears twice therein, which at the time of this comment are lines 17 and 119
-    DEFAULT_PATTERN = "**/*.{rb,js,coffee,css,scss,sass,erb,html,haml,ru,yml,slim,md,feature,c,h}"
+    DEFAULT_PATTERN = "**/*.{rb,js,coffee,css,scss,sass,erb,html,haml,ru,yml,slim,md,feature,c,h,cpp,hpp,py}"
     DEFAULT_DIRS = ["."]
 
     DEFAULTS = {


### PR DESCRIPTION
I frequently find myself having to manually type out the pattern for `cpp`, `hpp`, and `py` files that I work with a lot.  I propose we add them to the default and support more languages.