### PR TITLE
Fix no ignore dotfiles

### DIFF
--- a/lib/rerun/runner.rb
+++ b/lib/rerun/runner.rb
@@ -21,6 +21,8 @@ module Rerun
     def initialize(run_command, options = {})
       @run_command, @options = run_command, options
       @run_command = "ruby #{@run_command}" if @run_command.split(' ').first =~ /\.rb$/
+      @options[:directory] ||= options.delete(:dir) || '.'
+      @options[:ignore] ||= []
     end
 
     def start_keypress_thread
@@ -94,19 +96,11 @@ module Rerun
     end
 
     def dir
-      @options[:dir]
-    end
-
-    def dirs
-      @options[:dir] || "."
+      @options[:directory]
     end
 
     def pattern
       @options[:pattern]
-    end
-
-    def ignore
-      @options[:ignore] || []
     end
 
     def clear?
@@ -208,6 +202,7 @@ module Rerun
         end
         watcher.start
         @watcher = watcher
+        ignore = @options[:ignore]
         say "Watching #{dir.join(', ')} for #{pattern}" +
               (ignore.empty? ? "" : " (ignoring #{ignore.join(',')})") +
               (watcher.adapter.nil? ? "" : " with #{watcher.adapter_name} adapter")

--- a/lib/rerun/runner.rb
+++ b/lib/rerun/runner.rb
@@ -4,6 +4,9 @@ require 'io/wait'
 module Rerun
   class Runner
 
+    # The watcher instance that wait for changes
+    attr_reader :watcher
+
     def self.keep_running(cmd, options)
       runner = new(cmd, options)
       runner.start
@@ -198,11 +201,8 @@ module Rerun
       end
 
       unless @watcher
-
-        watcher = Watcher.new(:directory => dirs, :pattern => pattern, :ignore => ignore, :force_polling => force_polling) do |changes|
-
+        watcher = Watcher.new(@options) do |changes|
           message = change_message(changes)
-
           say "Change detected: #{message}"
           restart unless @restarting
         end

--- a/lib/rerun/runner.rb
+++ b/lib/rerun/runner.rb
@@ -304,7 +304,7 @@ module Rerun
           return true if success
         end
       end
-    rescue => e
+    rescue
       false
     end
 

--- a/lib/rerun/watcher.rb
+++ b/lib/rerun/watcher.rb
@@ -18,7 +18,7 @@ module Rerun
     #  Listen::Silencer.new(Listen::Listener.new).send :_default_ignore_patterns
     #end
 
-    attr_reader :directory, :pattern, :priority
+    attr_reader :directory, :pattern, :priority, :ignore_dotfiles
 
     # Create a file system watcher. Start it by calling #start.
     #
@@ -84,9 +84,8 @@ module Rerun
     end
 
     def ignoring
-      # todo: --no-ignore-dotfiles
       patterns = []
-      if (@ignore_dotfiles)
+      if ignore_dotfiles
         patterns << /^\.[^.]/ # at beginning of string, a real dot followed by any other character
       end
       patterns + @ignore.map { |x| Rerun::Glob.new(x).to_regexp }
@@ -131,6 +130,5 @@ module Rerun
     def adapter_name
       adapter && adapter.class.name.split('::').last
     end
-
   end
 end

--- a/lib/rerun/watcher.rb
+++ b/lib/rerun/watcher.rb
@@ -106,7 +106,7 @@ module Rerun
     # wait for the file watcher to finish
     def join
       @thread.join if @thread
-    rescue Interrupt => e
+    rescue Interrupt
       # don't care
     end
 

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -39,6 +39,13 @@ module Rerun
         runner.verbose?.should == true
       end
 
+      it "starts a watcher with the given options" do
+        options = Rerun::Options::DEFAULTS.dup.merge(ignore_dotfiles: false)
+        runner = Runner.new("foo.rb", options)
+        runner.start
+        runner.watcher.ignore_dotfiles.should be_falsey
+      end
+
       # TODO: test that quiet actually suppresses output
       # TODO: test that verbose actually shows more output
       # TODO: warn that verbose is overridden by quiet if you specify both


### PR DESCRIPTION
The option `--no-ignore-dotfiles` was not getting to the watcher, because the Runner were not sending it. To fix that, I make the runner pass all the options hash to the watcher.

Also, I removed some option reader methods that adds defaults to the initializer, making the options hash a single source of truth (to prevent this kind of issues).

Closes #117 .