### PR TITLE
Remove hardcoded string process call

### DIFF
--- a/lib/goo.rb
+++ b/lib/goo.rb
@@ -1,3 +1,0 @@
-goooo
-goooo
-goooo

--- a/lib/rerun/notification.rb
+++ b/lib/rerun/notification.rb
@@ -1,9 +1,8 @@
 # todo: unit tests
+require 'open3'
 
 module Rerun
   class Notification
-    include System
-
     attr_reader :title, :body, :options
 
     def initialize(title, body, options = Options::DEFAULTS.dup)
@@ -14,45 +13,43 @@ module Rerun
 
     def command
       # todo: strategy or subclass
-
-      s = nil
-
-      if options[:notify] == true or options[:notify] == "growl"
-        if (cmd = command_named("growlnotify"))
+      if (options[:notify] == true or options[:notify] == 'growl') and EXISTING_NOTIFIERS.include?('growlnotify')
           # todo: check version of growlnotify and warn if it's too old
-          icon_str = ("--image \"#{icon}\"" if icon)
-          s = "#{cmd} -n \"#{app_name}\" -m \"#{body}\" \"#{app_name} #{title}\" #{icon_str}"
-        end
+          cmd = ['growlnotify', '-n', app_name, '-m', body, "#{app_name} #{title}"]
+          cmd += ['--image', icon] if icon
+          return cmd
       end
 
-      if s.nil? and options[:notify] == true or options[:notify] == "osx"
-        if (cmd = command_named("terminal-notifier"))
-          icon_str = ("-appIcon \"#{icon}\"" if icon)
-          s = "#{cmd} -title \"#{app_name}\" -message \"#{body}\" \"#{app_name} #{title}\" #{icon_str}"
-        end
+      if (options[:notify] == true or options[:notify] == 'osx' ) and EXISTING_NOTIFIERS.include?('terminal-notifier')
+        cmd = ['terminal-notifier', '-title', app_name, '-message', body, "#{app_name} #{title}"]
+        cmd += ['-appIcon', icon] if icon
+        return cmd
       end
 
-      if s.nil? and options[:notify] == true or options[:notify] == "notify-send"
-        if (cmd = command_named('notify-send'))
+      if (options[:notify] == true or options[:notify] == "notify-send") and EXISTING_NOTIFIERS.include?('notify-send')
           icon_str = "--icon #{icon}" if icon
-          s = "#{cmd} -t 500 --hint=int:transient:1 #{icon_str} \"#{app_name}: #{title}\" \"#{body}\""
-        end
+          cmd = ['notify-send', '-t', '500', '--hint=int:transient:1', "#{app_name}: #{title}", body]
+          cmd += ['--icon', icon] if icon
+          return cmd
       end
 
-      s
+      nil
     end
 
-    def command_named(name)
-      which_command = windows? ? 'where.exe %{cmd}' : 'which %{cmd} 2> /dev/null'
-      # TODO: remove 'INFO' error message
-      path = `#{which_command % {cmd: name}}`.chomp
-      path.empty? ? nil : path
+    def self.command_exist?(name)
+        which = System.windows? ? 'where.exe' : 'which'
+        *_, status = Open3.capture3 which, name
+        status.exitstatus == 0
     end
+
+    EXISTING_NOTIFIERS = %w[growlnotify terminal-notifier notify-send]
+                              .select { |n| command_exist? n }
+                              .freeze
 
     def send(background = true)
       return unless command
       with_clean_env do
-        `#{command}#{" &" if background}`
+        Open3.capture3 *command
       end
     end
 
@@ -61,7 +58,7 @@ module Rerun
     end
 
     def icon
-      "#{icon_dir}/rails_red_sml.png" if rails?
+      "#{icon_dir}/rails_red_sml.png" if System.rails?
     end
 
     def icon_dir

--- a/lib/rerun/options.rb
+++ b/lib/rerun/options.rb
@@ -9,9 +9,6 @@ $spec = Gem::Specification.load(File.join(libdir, "..", "rerun.gemspec"))
 
 module Rerun
   class Options
-
-    extend Rerun::System
-
     # If you change the default pattern, please update the README.md file -- the list appears twice therein, which at the time of this comment are lines 17 and 119
     DEFAULT_PATTERN = "**/*.{rb,js,coffee,css,scss,sass,erb,html,haml,ru,yml,slim,md,feature,c,h}"
     DEFAULT_DIRS = ["."]
@@ -26,7 +23,7 @@ module Rerun
       :notify => true,
       :pattern => DEFAULT_PATTERN,
       :quiet => false,
-      :signal => (windows? ? "TERM,KILL" : "TERM,INT,KILL"),
+      :signal => (System.windows? ? "TERM,KILL" : "TERM,INT,KILL"),
       :verbose => false,
       :wait => 2,
     }

--- a/lib/rerun/runner.rb
+++ b/lib/rerun/runner.rb
@@ -3,7 +3,6 @@ require 'io/wait'
 
 module Rerun
   class Runner
-
     # The watcher instance that wait for changes
     attr_reader :watcher
 
@@ -15,7 +14,6 @@ module Rerun
       sleep 10000 while true # :-(
     end
 
-    include System
     include ::Timeout
 
     def initialize(run_command, options = {})
@@ -251,7 +249,7 @@ module Rerun
     # @returns false if either sending the signal fails or the process fails to die
     def signal_and_wait(signal)
 
-      signal_sent = if windows?
+      signal_sent = if System.windows?
                       force_kill = (signal == 'KILL')
                       system("taskkill /T #{'/F' if force_kill} /PID #{@pid}")
                     else
@@ -332,7 +330,7 @@ module Rerun
     # returns a 1-char string if a key was pressed; otherwise nil
     #
     def key_pressed
-      return one_char if windows?
+      return one_char if System.windows?
       begin
         # this "raw input" nonsense is because unix likes waiting for linefeeds before sending stdin
 

--- a/lib/rerun/system.rb
+++ b/lib/rerun/system.rb
@@ -1,22 +1,20 @@
 module Rerun
   module System
-
-    def mac?
+    def self.mac?
       RUBY_PLATFORM =~ /darwin/i
     end
 
-    def windows?
+    def self.windows?
        RUBY_PLATFORM =~ /(mswin|mingw32)/i
     end
 
-    def linux?
+    def self.linux?
        RUBY_PLATFORM =~ /linux/i
     end
 
-    def rails?
-      rails_sig_file = File.expand_path(".")+"/config/boot.rb"
+    def self.rails?
+      rails_sig_file = File.expand_path File.join '.', 'config/boot.rb'
       File.exists? rails_sig_file
     end
-
   end
 end

--- a/rerun.gemspec
+++ b/rerun.gemspec
@@ -3,7 +3,7 @@ $spec = Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
 
   s.name = 'rerun'
-  s.version = '0.13.1'
+  s.version = '0.14.0'
 
   s.description = "Restarts your app when a file changes. A no-frills, command-line alternative to Guard, Shotgun, Autotest, etc."
   s.summary     = "Launches an app, and restarts it whenever the filesystem changes. A no-frills, command-line alternative to Guard, Shotgun, Autotest, etc."

--- a/spec/functional_spec.rb
+++ b/spec/functional_spec.rb
@@ -2,7 +2,6 @@ here = File.expand_path(File.dirname(__FILE__))
 require "#{here}/spec_helper.rb"
 require "#{here}/inc_process.rb"
 
-
 describe "the rerun command" do
   before do
     STDOUT.sync = true
@@ -80,9 +79,8 @@ describe "the rerun command" do
 
   #it "sends its child process a SIGINT to restart"
 
-  include ::Rerun::System
   it "dies when sent a control-C (SIGINT)" do
-    unless windows?
+    unless Rerun::System.windows?
       pid = @inc.inc_parent_pid
       # puts "test sending INT to #{pid}"
       Process.kill("INT", pid)

--- a/spec/inc_process.rb
+++ b/spec/inc_process.rb
@@ -1,10 +1,8 @@
 here = File.expand_path(File.dirname(__FILE__))
 require 'tmpdir'
+require 'open3'
 require_relative('../lib/rerun/system')
 class IncProcess
-
-  include Rerun::System
-
   attr_reader :dir, :inc_output_file
   attr_reader :dir1, :dir2
   attr_reader :rerun_pid, :inc_parent_pid
@@ -29,8 +27,8 @@ class IncProcess
       pids = ([@inc_pid, @inc_parent_pid, @rerun_pid] - [Process.pid]).uniq
       ::Timeout.timeout(5) do
         pids.each do |pid|
-          if windows?
-            system("taskkill /F /T /PID #{pid}")
+          if Rerun::System.windows?
+            Open3.capture2('taskkill', '/F', '/T', '/PID', pid.to_s)
           else
             # puts "Killing #{pid} gracefully"
             Process.kill("INT", pid) rescue Errno::ESRCH
@@ -93,5 +91,3 @@ class IncProcess
   end
 
 end
-
-


### PR DESCRIPTION
Avoid stderr pollution from `/usr/bin/which` when binary not found in path & shell string injection