### PR TITLE
Update .exists? -> .exist? for Ruby 3.* compat

### DIFF
--- a/lib/rerun/runner.rb
+++ b/lib/rerun/runner.rb
@@ -311,7 +311,7 @@ module Rerun
 
     def read_git_head
       git_head_file = File.join(dir, '.git', 'HEAD')
-      @git_head = File.exists?(git_head_file) && File.read(git_head_file)
+      @git_head = File.exist?(git_head_file) && File.read(git_head_file)
     end
 
     def notify(title, body, background = true)

--- a/lib/rerun/system.rb
+++ b/lib/rerun/system.rb
@@ -15,7 +15,7 @@ module Rerun
 
     def rails?
       rails_sig_file = File.expand_path(".")+"/config/boot.rb"
-      File.exists? rails_sig_file
+      File.exist? rails_sig_file
     end
 
   end

--- a/lib/rerun/watcher.rb
+++ b/lib/rerun/watcher.rb
@@ -50,7 +50,7 @@ module Rerun
       dirs = [*dirs]
       dirs.map do |d|
         d.chomp!("/")
-        unless FileTest.exists?(d) && FileTest.readable?(d) && FileTest.directory?(d)
+        unless FileTest.exist?(d) && FileTest.readable?(d) && FileTest.directory?(d)
           raise InvalidDirectoryError, "Directory '#{d}' either doesnt exist or isn't readable"
         end
         File.expand_path(d)


### PR DESCRIPTION
`.exists?` no longer exists in Ruby 3.2