### PR TITLE
runner: use IO#wait_readable when available

### DIFF
--- a/lib/rerun/runner.rb
+++ b/lib/rerun/runner.rb
@@ -364,7 +364,9 @@ module Rerun
     private
     def one_char
       c = nil
-      if $stdin.ready?
+      msg = $stdin.respond_to?(:wait_readable) ? :wait_readable : :ready?
+
+      if $stdin.send(msg)
         c = $stdin.getc
       end
       c.chr if c


### PR DESCRIPTION
Ruby 4.0 removed `IO#ready?` in favor of `IO#wait_readable`.

See https://github.com/ruby/ruby/commit/b70f5afb68253eb25cf5f8f2fdfbf01dae1d05d3